### PR TITLE
Fix tests to run offline with ONLINE flag

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "main": "dist/main.js",
   "type": "module",
   "scripts": {
-    "test": "vitest run",
+    "test": "vitest run --passWithNoTests",
     "code": "code --extensionDevelopmentPath=. --disable-extensions",
     "build": "vite build",
     "dev": "vite",

--- a/src/lib/pyodide/executor.ts
+++ b/src/lib/pyodide/executor.ts
@@ -16,7 +16,17 @@ export class PyodideExecutor {
     return new Promise<void>(async (resolve, reject) => {
       try {
         // Use Vite's worker import syntax which will be properly bundled
-        const blob = new Blob([workerCode], { type: "application/javascript" });
+        let code = "";
+        if (typeof window !== "undefined") {
+          if ((window as any).PYODIDE_BASE_URL) {
+            code += `self.PYODIDE_BASE_URL = "${(window as any).PYODIDE_BASE_URL}";\n`;
+          }
+          if ((window as any).COMLINK_URL) {
+            code += `self.COMLINK_URL = "${(window as any).COMLINK_URL}";\n`;
+          }
+        }
+        code += workerCode;
+        const blob = new Blob([code], { type: "application/javascript" });
         const workerUrl = URL.createObjectURL(blob);
         this.worker = new Worker(workerUrl);
         // this.worker = new PyodideWorker();

--- a/src/lib/pyodide/worker.js
+++ b/src/lib/pyodide/worker.js
@@ -5,8 +5,13 @@
 self.process = undefined;
 self.Deno = undefined;
 
-importScripts("https://unpkg.com/comlink/dist/umd/comlink.js");
-importScripts("https://cdn.jsdelivr.net/pyodide/v0.27.4/full/pyodide.js");
+const COMLINK_URL =
+  self.COMLINK_URL || "https://unpkg.com/comlink/dist/umd/comlink.js";
+const PYODIDE_BASE_URL =
+  self.PYODIDE_BASE_URL || "https://cdn.jsdelivr.net/pyodide/v0.27.4/full/";
+
+importScripts(COMLINK_URL);
+importScripts(`${PYODIDE_BASE_URL}pyodide.js`);
 
 class Worker {
   pyodide = null;
@@ -14,7 +19,7 @@ class Worker {
 
   async init() {
     this.pyodide = await loadPyodide({
-      indexURL: "https://cdn.jsdelivr.net/pyodide/v0.27.4/full/",
+      indexURL: PYODIDE_BASE_URL,
     });
     // Save the original stdout write function
     this.pyodide.runPython(`

--- a/src/pglite/provider.ts
+++ b/src/pglite/provider.ts
@@ -1,7 +1,14 @@
 import type { PGlite } from "@electric-sql/pglite";
 
 const PGLITE_VERSION = "0.2.17";
-const CDN_URL = `https://cdn.jsdelivr.net/npm/@electric-sql/pglite@${PGLITE_VERSION}/dist/index.js`;
+const DEFAULT_CDN_URL = `https://cdn.jsdelivr.net/npm/@electric-sql/pglite@${PGLITE_VERSION}/dist/index.js`;
+
+function getPgliteUrl() {
+  if (typeof window !== "undefined" && (window as any).PGLITE_URL) {
+    return (window as any).PGLITE_URL as string;
+  }
+  return DEFAULT_CDN_URL;
+}
 
 export class PGliteProvider {
   private pgClient: PGlite | null = null;
@@ -58,14 +65,15 @@ export class PGliteProvider {
       };
 
       // Create PGlite instance with options
-      const module = await import(/* @vite-ignore */ CDN_URL);
+      const module = await import(/* @vite-ignore */ getPgliteUrl());
       const PGliteClass: typeof PGlite = module.PGlite;
       return await PGliteClass.create({
         dataDir: "idb://agent-sandbox",
         relaxedDurability: this.relaxedDurability,
         extensions: {
           vector: new URL(
-            `https://unpkg.com/@electric-sql/pglite@${PGLITE_VERSION}/dist/vector.tar.gz`,
+            (typeof window !== "undefined" && (window as any).PGLITE_VECTOR_URL) ||
+              `https://unpkg.com/@electric-sql/pglite@${PGLITE_VERSION}/dist/vector.tar.gz`,
           ),
         },
       });

--- a/tests/pglite.test.ts
+++ b/tests/pglite.test.ts
@@ -10,6 +10,10 @@ interface PGliteResult {
 }
 
 describe("PGlite CDN Tests", () => {
+  beforeAll(() => {
+    (window as any).PGLITE_URL = `${location.origin}/node_modules/@electric-sql/pglite/dist/index.js`;
+    (window as any).PGLITE_VECTOR_URL = `${location.origin}/node_modules/@electric-sql/pglite/dist/vector.tar.gz`;
+  });
   let pglite: PGlite;
   let provider: PGliteProvider;
 

--- a/tests/pyodide/executor.test.ts
+++ b/tests/pyodide/executor.test.ts
@@ -1,7 +1,13 @@
 import { describe, it, expect, beforeAll, afterAll, vi } from "vitest";
 import { PyodideExecutor } from "../../src/lib/pyodide/executor";
 
-describe("PyodideExecutor Tests", () => {
+const describeIf = import.meta.env.ONLINE === "false" ? describe.skip : describe;
+
+describeIf("PyodideExecutor Tests", () => {
+  beforeAll(() => {
+    (window as any).PYODIDE_BASE_URL = `${location.origin}/node_modules/pyodide/`;
+    (window as any).COMLINK_URL = `${location.origin}/node_modules/comlink/dist/umd/comlink.js`;
+  });
   let executor: PyodideExecutor;
 
   beforeAll(async () => {

--- a/tests/pyodide/pyodide.test.ts
+++ b/tests/pyodide/pyodide.test.ts
@@ -1,7 +1,13 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { PyodideExecutor } from "../../src/lib/pyodide/executor";
 
-describe("Pyodide Basic Tests", () => {
+const describeIf = import.meta.env.ONLINE === "false" ? describe.skip : describe;
+
+describeIf("Pyodide Basic Tests", () => {
+  beforeAll(() => {
+    (window as any).PYODIDE_BASE_URL = `${location.origin}/node_modules/pyodide/`;
+    (window as any).COMLINK_URL = `${location.origin}/node_modules/comlink/dist/umd/comlink.js`;
+  });
   let executor: PyodideExecutor;
 
   beforeAll(async () => {

--- a/tests/pyodide/requests.test.ts
+++ b/tests/pyodide/requests.test.ts
@@ -1,7 +1,13 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { PyodideExecutor } from "../../src/lib/pyodide/executor";
 
-describe("Pyodide HTTP Request Tests", () => {
+const describeIf = import.meta.env.ONLINE === "false" ? describe.skip : describe;
+
+describeIf("Pyodide HTTP Request Tests", () => {
+  beforeAll(() => {
+    (window as any).PYODIDE_BASE_URL = `${location.origin}/node_modules/pyodide/`;
+    (window as any).COMLINK_URL = `${location.origin}/node_modules/comlink/dist/umd/comlink.js`;
+  });
   let executor: PyodideExecutor;
 
   beforeAll(async () => {

--- a/tests/tools/execute-python.test.ts
+++ b/tests/tools/execute-python.test.ts
@@ -1,7 +1,13 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeAll } from "vitest";
 import { executePython } from "../../src/tools/execute.ts";
 
-describe("Execute Python Tool Tests", () => {
+const describeIf = import.meta.env.ONLINE === "false" ? describe.skip : describe;
+
+describeIf("Execute Python Tool Tests", () => {
+  beforeAll(() => {
+    (window as any).PYODIDE_BASE_URL = `${location.origin}/node_modules/pyodide/`;
+    (window as any).COMLINK_URL = `${location.origin}/node_modules/comlink/dist/umd/comlink.js`;
+  });
   const options = {
     toolCallId: "test-tool-call-id",
     messages: [],
@@ -43,7 +49,9 @@ describe("Execute Python Tool Tests", () => {
     expect(result.error).toContain("NameError");
   });
 
-  it("should install and use packages", async () => {
+  const itIfOnline = import.meta.env.ONLINE === "false" ? it.skip : it;
+
+  itIfOnline("should install and use packages", async () => {
     // This test uses numpy, a common Python package
     const result = await executePython({
       code: `

--- a/tests/tools/markdown-tool.test.ts
+++ b/tests/tools/markdown-tool.test.ts
@@ -366,3 +366,6 @@
 //     expect(result.error).toContain("not found in tools/execute.ts");
 //   });
 // });
+
+export {};
+

--- a/tests/tools/text-editor-tool.test.ts
+++ b/tests/tools/text-editor-tool.test.ts
@@ -263,3 +263,6 @@
 //     expect(result.error).toContain("Multiple occurrences");
 //   });
 // });
+
+export {};
+

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -54,6 +54,7 @@ export default defineConfig(({ command }) => {
   });
 
   return {
+    envPrefix: ["VITE_", "ONLINE"],
     resolve: {
       alias: {
         $lib: path.resolve("./src/lib"),


### PR DESCRIPTION
## Summary
- allow tests to skip when `ONLINE=false`
- expose `ONLINE` env var via Vite `envPrefix`
- remove placeholder suites and rely on Vitest `--passWithNoTests`

## Testing
- `CI=true ONLINE=false npm test`
- `CI=true ONLINE=true npm test` *(fails as expected without network)*